### PR TITLE
LabLab 2016 Ankündigung

### DIFF
--- a/_posts/2016-04-12-lablab.md
+++ b/_posts/2016-04-12-lablab.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title: Lab Lab 2016 - das Vernetzungstreffen für FabLabs
+date: 2016-04-11
+author: Max (FAU FabLab Erlangen)
+header-img: "img/fab10_fau.jpg"
+---
+
+Lab Lab 2016 - das Vernetzungstreffen für FabLabs
+
+Bereits zum dritten Mal findet in Nürnberg das Lab Lab statt. Was ist das? Das Labor für die FabLabs - hier treffen sich die Betreiber von FabLabs und tauschen sich aus. Und nicht nur das: Dieses Jahr sollen auch zukünftige Aktivitäten für FabLabs entwickelt werden. 
+
+Stattfinden wird es am 3./4. Juni in Nürnberg - im Heizhaus der alten Quelle. Ihr seid alle herzlich eingeladen, daran teilzunehmen - [hier](http://projekt-metrolab.de/lablab) geht es zu allen Informationen und zur Anmeldung.


### PR DESCRIPTION
Die Einladung zum Vernetzungstreffen sollte auch auf die Fabrikationslabor Webseite.

(Ich hoffe mal die Syntax stimmt...)
