### PR TITLE
Labs: +Freising, -Regensburg, Update Nürnberger Land

### DIFF
--- a/fablabs-in-deutschland.html
+++ b/fablabs-in-deutschland.html
@@ -10,8 +10,8 @@ header-img: "img/map.png"
 <iframe src="https://www.fablabs.io/labs/embed">Karte auf https://www.fablabs.io/labs/embed</iframe>
 <p>In Deutschland gibt es in fast jeder grösseren Stadt ein FabLab oder eine Gruppe von engagierten Makern, die ein solches eröffnen wollen.</p>
 <p>Hier eine Liste der uns bekannten Labs (ein Häkchen gibt an, dass das Lab bei Fablab4Germany aktiv ist):</p>
-<!-- möchte man irgendwie signalisieren, wer bei fablab4germany schon mit vernetzt ist? z.B. durch unterschiedliche listen bullet point farbe oder so -->
 <ul class="fa-ul">
+<!-- Labs, die bei fablab4germany dabei sind, kriegen ein Häkchen mittels:  <i class="fa-li fa fa-check-square"></i> -->
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://fablab-aachen.de" target="_blank">Aachen</a> (an der RWTH Aachen)</li>
   <li>FabLab <a href="http://fablab-allgaeu.de/" target="_blank">Allgäu (Kempten)</a></li>
   <li>FabLab <a href="http://www.fablab-ansbach.de/" target="_blank">Ansbach</a> (im Aufbau)</li>
@@ -30,6 +30,7 @@ header-img: "img/map.png"
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://garage-lab.de" target="_blank">Düsseldorf</a> (GarageLab)</li>
   <!--noch prüfen<li>FabLab <a href="http://www.3d-druckzentrum-ruhr.de/" target="_blank">Essen</a></li>-->
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="https://fablab.fau.de" target="_blank">Erlangen</a> (an der FAU)</li>
+  <li>FabLab <a href="http://fablab-hamburg.org" target="_blank">Freising</a></li>
   <!--noch prüfen<li>Werkstatt eigenbaukombinat in Halle (Saale)</li>-->
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://fablab-hamburg.org" target="_blank">Hamburg</a> (Fabulous St. Pauli)</li>
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://fablab-ingolstadt.de/" target="_blank">Ingolstadt</a></li>
@@ -49,12 +50,11 @@ header-img: "img/map.png"
   <li>FabLab <a href="http://www.fablab-nea.de/" target="_blank">Neustadt a.d. Aisch / Bad Windsheim</a></li>
   <li>FabLab <a href="http://fablab-neumarkt.de" target="_blank">Neumarkt (Oberpfalz)</a></li>
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://fablab-nuernberg.de" target="_blank">Nürnberg</a> mit Projekt <a href="http://projekt-metrolab.de/" target="_blank">METROLAB</a> für die Metropolregion.</li>
-  <li>FabLab <a href="http://landkreis.nuernberger-land.de/index.php?id=2452" target="_blank">Nürnberger Land</a> (im Aufbau)</li>
+  <li>FabLab <a href="https://fablab.nueland.de/" target="_blank">Nürnberger Land</a></li>
   <li>FabLab <a href="http://fablab-paderborn.de" target="_blank">Paderborn</a></li>
   <li>FabLab <a href="http://www.eislab.net/fablab.html" target="_blank">Passau</a> als Teil des EISLab-Lehrstuhl</li><!-- noch nicht fablabs.io -->
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://www.wissenschaftsladen-potsdam.de/" target="_blank">Potsdam</a> (Wissenschaftsladen)</li>
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://fablab-rothenburg.de/" target="_blank">Rothenburg ob der Tauber</a></li>
-  <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://www.fablab-regensburg.de/" target="_blank">Regensburg</a></li>
   <li>FabLab <a href="http://bbz-nok.de/de/schueler/fablab.html" target="_blank">Rendsburg (BBZ am Nord-Ostsee-Kanal)</a></li>
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="https://jugendzentrum-schwabach.de/openlab/" target="_blank">Schwabach</a></li>
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://fablab-siegen.de/" target="_blank">Siegen</a></li>


### PR DESCRIPTION
Das FabLab Regensburg gibt es scheinbar nicht mehr.