### PR TITLE
Fixed the status of FabLab Chemnitz

### DIFF
--- a/fablabs-in-deutschland.html
+++ b/fablabs-in-deutschland.html
@@ -21,7 +21,7 @@ header-img: "img/map.png"
   <li>FabLab <a href="http://fablab.hochschule-ruhr-west.de/" target="_blank">Bottrop</a> (an der Hochschule Ruhr-West)</li>
   <li>FabLab <a href="http://fablab-bs.de/" target="_blank">Braunschweig</a></li>
   <li>FabLab <a href="http://fablab-bremen.org" target="_blank">Bremen</a></li>
-  <li>FabLab <a href="http://www.fablabchemnitz.de/" target="_blank">Chemnitz</a> (im Aufbau)</li>
+  <li>FabLab <a href="https://fablabchemnitz.de" target="_blank">Chemnitz</a></li>
   <li>FabLab <a href="http://fablab-cottbus.de/" target="_blank">Cottbus</a></li>
   <!-- nochmal prüfen, listet sich aber auch auf fablabs.io<li>L1A Makerspace <a href="http://www.l1a.de/" target="_blank">Darmstadt</a></li> -->
   <li>L1A Makerspace <a href="http://www.l1a.de/" target="_blank">Darmstadt</a></li>


### PR DESCRIPTION
The FabLab Chemnitz is established now since 13.01.2016 and is running under the hood of Stadtfabrikanten e.V. :-)
With this fix i'd like to join the mail subscription if possible.

cheers, Mario