### PR TITLE
added FabLab Altmühlfranken e.V.

### DIFF
--- a/fablabs-in-deutschland.html
+++ b/fablabs-in-deutschland.html
@@ -14,6 +14,7 @@ header-img: "img/map.png"
 <!-- Labs, die bei fablab4germany dabei sind, kriegen ein Häkchen mittels:  <i class="fa-li fa fa-check-square"></i> -->
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://fablab-aachen.de" target="_blank">Aachen</a> (an der RWTH Aachen)</li>
   <li>FabLab <a href="http://fablab-allgaeu.de/" target="_blank">Allgäu (Kempten)</a></li>
+  <li>FabLab <a href="https://fablab-altmuehlfranken.de/" target="_blank">Altmühlfranken e.V.</a> (in Gunzenhausen)</li>
   <li>FabLab <a href="http://www.fablab-ansbach.de/" target="_blank">Ansbach</a> (im Aufbau)</li>
   <li>FabLab <a href="http://www.fablab-bayreuth.de/" target="_blank">Bayreuth</a> IFLLab</li>
   <li><i class="fa-li fa fa-check-square"></i>FabLab <a href="http://www.fablab.berlin" target="_blank">Berlin</a></li>


### PR DESCRIPTION
Would be nice to have our FabLab Altmühlfranken e.V. in your list.
The Lab itself is located in Gunzenhausen, but it was foundet as a FabLab for the whole region Altmühlfranken.